### PR TITLE
basic georeferencing for netcdf

### DIFF
--- a/kafka/utils.py
+++ b/kafka/utils.py
@@ -254,8 +254,8 @@ class OutputFile(object):
         # create container variable for CRS: x/y WKT
         try:
             crso = self.nc.createVariable('crs', 'i4')
-            crso.grid_mapping_name("srs")
-            crso.crs_wkt(self.wkt)
+            crso.grid_mapping_name = 'srs'
+            crso.crs_wkt = self.wkt
         except AttributeError:
             print "Can't create a georeferenced netCDF file. Don't know why"
         xo[:] = self.x


### PR DESCRIPTION
To add georeferencing (see #2). 

This just specifies the coordinate system via WKT (a-la https://cf-trac.llnl.gov/trac/ticket/69) but doesn't try to fill out a full set of grid mapping attributes (e.g. like https://www.unidata.ucar.edu/software/thredds/current/netcdf-java/reference/StandardCoordinateTransforms.html)

Is this sufficient or do you need more?

Example header:

netcdf testfile2 {
dimensions:
        scalar = UNLIMITED ; // (0 currently)
        time = UNLIMITED ; // (0 currently)
        x = 2400 ;
        y = 2400 ;
variables:
        float time(time) ;
                time:units = "days since 1858-11-17 00:00:00" ;
                time:standard_name = "time" ;
                time:calendar = "Gregorian" ;
        float x(x) ;
                x:units = "m" ;
                x:standard_name = "projection_x_coordinate" ;
        float y(y) ;
                y:units = "m" ;
        int crs ;
                crs:grid_mapping_name = "srs" ;
                crs:crs_wkt = "PROJCS[\"unnamed\",GEOGCS[\"Unknown datum based upon the custom spheroid\",DATUM[\"Not specified (based on custom spheroid)\",SPHEROID[\"Custom spheroid\",6371007.181,0]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"longitude_of_center\",0],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"Meter\",1]]" ;

// global attributes:
                :Conventions = "CF-1.7" ;
data:


