### PR TITLE
Netcdf group

### DIFF
--- a/kafka/utils.py
+++ b/kafka/utils.py
@@ -368,6 +368,14 @@ class OutputFile(object):
         # varo[:,...] = vardata
 
     def update_time(self, time, index=np.s_[:]):
+        """
+        
+        :param time: array
+                    The times to be added to the time variable.
+        :param index: slice
+                    The slice defines where in the variable the times go.
+        :return: 
+        """
         varo = self.nc.variables['time']
         varo[index] = time
 

--- a/kafka/utils.py
+++ b/kafka/utils.py
@@ -367,6 +367,10 @@ class OutputFile(object):
         varo.set_auto_maskandscale(False)
         # varo[:,...] = vardata
 
+    def update_time(self, time, index=np.s_[:]):
+        varo = self.nc.variables['time']
+        varo[index] = time
+
     def update_variable(self, varname, vardata, group=None):
         """
         Appends data to a variable in the file.

--- a/kafka/utils.py
+++ b/kafka/utils.py
@@ -253,6 +253,7 @@ class OutputFile(object):
 
         yo = self.nc.createVariable('y', 'f4', ('y'))
         yo.units = 'm'
+        yo.standard_name = 'projection_y_coordinate'
         self.nc.Conventions = 'CF-1.7'
         # create container variable for CRS: x/y WKT
         try:


### PR DESCRIPTION
This makes 'group' an optional keyword argument when creating netcdf variables. This is necessary as gdal (at least version 2.1.0) can't read groups. (#10)

This update does break backwards compatibility as I've made group an optional keyword argument and moved its position in create_variable, create_empty_variable and update_variable to do so. If this is a problem then we can move it back and require the user to explicitly call group=None, but I'd prefer not to if we can cope with this change now.

still to-do. The time variable is not updated 